### PR TITLE
Fix "Malformed JSON in request body" error from Cloudflare API

### DIFF
--- a/cloudflare_ddns/cloudflare.py
+++ b/cloudflare_ddns/cloudflare.py
@@ -62,8 +62,7 @@ class CloudFlare:
         self.proxied = proxied
         self.headers = {
             'X-Auth-Key': api_key,
-            'X-Auth-Email': email,
-            'Content-Type': 'application/json'
+            'X-Auth-Email': email
         }
         self.setup_zone()
 
@@ -79,7 +78,7 @@ class CloudFlare:
         response = method(
             url,
             headers=self.headers,
-            data=self.process_json_for_cloudflare(data) if data else None
+            json=data
         )
         content = response.json()
         if response.status_code != 200:
@@ -270,12 +269,3 @@ class CloudFlare:
                       .format(old_ip=record['content'], new_ip=ip_address))
             else:
                 print('IP address on CloudFlare is same as your current address')
-
-    @staticmethod
-    def process_json_for_cloudflare(data_dict):
-        """
-        Need to process the data because of the odd format requirement from CloudFlare
-        :param data_dict:
-        :return:
-        """
-        return str(data_dict).replace('"', 'double_quote').replace("'", '"').replace('double_quote', "'")


### PR DESCRIPTION
Trying to use the module I encountered a problem: Cloudflare returned the following error when I had called `cf.sync_dns_from_my_ip()`:

    {'success': False, 'errors': [{'code': 6007, 'message': 'Malformed JSON in request body'}], 'messages': [], 'result': None}
    File "D:/~TEMP/cloudflare-ddns/test.py", line 20, in <module>
        cf.sync_dns_from_my_ip()
      File "D:\~TEMP\cloudflare-ddns\cloudflare_ddns\cloudflare.py", line 266, in sync_dns_from_my_ip
        self.update_record(dns_type, self.domain, ip_address, proxied=True)
      File "D:\~TEMP\cloudflare-ddns\cloudflare_ddns\cloudflare.py", line 188, in update_record
        data=data
      File "D:\~TEMP\cloudflare-ddns\cloudflare_ddns\cloudflare.py", line 87, in request
        raise requests.HTTPError(content['message'])
    KeyError: 'message'

Then I removed the `process_json_for_cloudflare` function and the manual use of a `Content-Type` header  in favor of the built-in mechanism of Requests library. This fixed the issue:

    DNS record successfully updated
    Successfully updated IP address from X.X.X.X to Y.Y.Y.Y