### PR TITLE
improved handling of domains with more than two periods

### DIFF
--- a/cloudflare_ddns/cloudflare.py
+++ b/cloudflare_ddns/cloudflare.py
@@ -94,15 +94,21 @@ class CloudFlare:
         """
         # Initialize current zone
         zones_content = self.request(self.api_url, 'get')
+        domain_segments=self.domain.split(".")
+        
+        #join the last two segments of the domain name.
+        domain = domain_segments[-2] + "." + domain_segments[-1]
+        
         try:
-            if len(self.domain.split('.')) == 3:
-                domain = self.domain.split('.', 1)[1]
-            else:
-                domain = self.domain
             zone = [zone for zone in zones_content['result'] if zone['name'] == domain][0]
         except IndexError:
-            raise ZoneNotFound('Cannot find zone information for the domain {domain}.'
-                               .format(domain=self.domain))
+            # if that's not on the list, try with three segments instead
+            domain = domain_segments[-3] + "." + domain
+            try:
+                zone = [zone for zone in zones_content['result'] if zone['name'] == domain][0]
+            except IndexError:
+                raise ZoneNotFound('Cannot find zone information for the domain {domain}.'
+                                   .format(domain=self.domain))
         self.zone = zone
 
         # Initialize dns_records of current zone


### PR DESCRIPTION
This splits the domain into segments based on where the periods lie, and tries to find a zone using the last two segments - if that files, it tries to find a zone with the last three.

Here are some cases where this is useful:

- example.co.uk
    Under the previous algorithm, `self.domain.split('.', 1)[1]` would just pull the last two segments (co.uk), and miss the existing DNS zone for example.co.uk. With this change, it will first attempt co.uk, then try example.co.uk if that fails.

- www.subdomain.example.com
    In this case, the previous algorithm would attempt to pull a DNS zone for subdomain.example.com and miss the DNS zone for example.com. With this change, it will first attempt to load example.com correctly. If that were to fail (for example, in www.subdomain.example.co.uk), it will then attempt to go a level deeper (example.com.uk). 